### PR TITLE
Preserve DataGrid visual selection when a custom Comparer is provided or items are refreshed

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSelectionComparerRefreshTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSelectionComparerRefreshTest.razor
@@ -1,0 +1,46 @@
+﻿<MudDataGrid T="Person" Items="_people" @bind-SelectedItems="_selectedItems" Comparer="_comparer" MultiSelection>
+    <Columns>
+        <SelectColumn ShowInFooter="false" />
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private readonly IEqualityComparer<Person> _comparer = new PersonIdComparer();
+    private HashSet<Person> _selectedItems = [];
+    private List<Person> _people =
+    [
+        new() { Id = 1, Name = "One" },
+        new() { Id = 2, Name = "Two" }
+    ];
+
+    public void RefreshItems()
+    {
+        _people =
+        [
+            new() { Id = 1, Name = "One" },
+            new() { Id = 2, Name = "Two" }
+        ];
+
+        StateHasChanged();
+    }
+
+    public class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class PersonIdComparer : IEqualityComparer<Person>
+    {
+        public bool Equals(Person? x, Person? y)
+        {
+            return x?.Id == y?.Id;
+        }
+
+        public int GetHashCode(Person obj)
+        {
+            return obj.Id;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -570,6 +570,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridCustomComparer_ShouldKeepVisualSelectionAfterItemsRefresh()
+        {
+            var comp = Context.Render<DataGridSelectionComparerRefreshTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionComparerRefreshTest.Person>>();
+
+            await dataGrid.FindAll("input[type=checkbox]")[1].ChangeAsync(true);
+
+            dataGrid.Instance.GetState(x => x.SelectedItems).Should().HaveCount(1);
+            dataGrid.FindAll("input[type=checkbox]").Count(checkbox => checkbox.IsChecked()).Should().Be(1);
+
+            await comp.InvokeAsync(() => comp.Instance.RefreshItems());
+
+            dataGrid.Instance.GetState(x => x.SelectedItems).Should().HaveCount(1);
+            dataGrid.FindAll("input[type=checkbox]").Count(checkbox => checkbox.IsChecked()).Should().Be(1);
+        }
+
+        [Test]
         public async Task DataGridSingleSelection()
         {
             var comp = Context.Render<DataGridSingleSelectionTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -143,6 +143,12 @@ namespace MudBlazor
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
+
+            if (Comparer is not null && !ReferenceEquals(Selection.Comparer, Comparer))
+            {
+                Selection = new HashSet<T>(Selection, Comparer);
+            }
+
             if (Items != null)
             {
                 if (ServerData != null)


### PR DESCRIPTION
### Motivation
- Ensure that when a custom `Comparer` is supplied to `MudDataGrid<T>` the internal selection set uses that comparer so visual selection (checked checkboxes) remains consistent after the items source is refreshed or replaced.

### Description
- Recreate the selection set with the supplied comparer in `OnParametersSet` by doing `Selection = new HashSet<T>(Selection, Comparer)` when `Comparer` is not null and not `ReferenceEquals` to the current comparer. 
- Add a test component `DataGridSelectionComparerRefreshTest.razor` which exposes a `RefreshItems` method and uses a `PersonIdComparer` to simulate an items refresh scenario. 
- Add unit test `DataGridCustomComparer_ShouldKeepVisualSelectionAfterItemsRefresh` to `DataGridTests.cs` which checks that the selected items count and the checked checkbox count remain correct after calling `RefreshItems`.

### Testing
- Ran the updated DataGrid unit tests including the new `DataGridCustomComparer_ShouldKeepVisualSelectionAfterItemsRefresh` test, and it passed. 
- Existing DataGrid selection tests were executed and continued to pass after the change. 
- The new component `DataGridSelectionComparerRefreshTest.razor` is used by the unit test to validate behavior under an items refresh and custom comparer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad66b801c4832da27db71ea1e6cc5d)