### PR TITLE
Add horizontal reorder preview support to MudDropZone and update docs/tests

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DropZone/DropZonePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/DropZonePage.razor
@@ -51,6 +51,7 @@
                     <SectionHeader Title="Reorder items">
                         <Description>
                             Items can be reordered inside each dropzone with the <CodeInline>AllowReorder</CodeInline> bool set to true on the dropzone.
+                            Set <CodeInline>Horizontal</CodeInline> to <CodeInline>true</CodeInline> when the dropzone renders reorderable items in a horizontal row.
                         </Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" ShowCode="false" Code="@nameof(DropZoneItemSelectorReorderingExample)">

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneItemSelectorReorderingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneItemSelectorReorderingExample.razor
@@ -7,8 +7,8 @@
             var dropzone = i.ToString();
             <MudPaper Class="ma-4 flex-grow-1">
                 <MudList T="string" Class="d-flex flex-column mud-height-full">
-                    <MudListSubheader>Drop Zone @dropzone</MudListSubheader>
-                    <MudDropZone T="DropItem" Identifier="@dropzone" Class="flex-grow-1" AllowReorder="true" />
+                    <MudListSubheader>Drop Zone @dropzone @((i == 1) ? "(Horizontal=true)" : string.Empty)</MudListSubheader>
+                    <MudDropZone T="DropItem" Identifier="@dropzone" Class="@((i == 1) ? "d-flex flex-row flex-wrap flex-grow-1" : "flex-grow-1")" AllowReorder="true" Horizontal="@(i == 1)" />
                 </MudList>
             </MudPaper>
         }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneHorizontalReorderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneHorizontalReorderTest.razor
@@ -1,0 +1,28 @@
+﻿<MudDropContainer T="DropItem" Items="_items" ItemsSelector="@((item, dropzone) => item.Selector == dropzone)" Class="d-flex flex-wrap">
+    <ChildContent>
+        <MudPaper Class="ma-4 flex-grow-1">
+            <MudList T="string" Class="d-flex flex-column mud-height-full">
+                <MudListSubheader>Horizontal Drop Zone</MudListSubheader>
+                <MudDropZone T="DropItem" Identifier="1" Class="d-flex flex-row flex-wrap" AllowReorder="true" Horizontal="true" />
+            </MudList>
+        </MudPaper>
+    </ChildContent>
+    <ItemRenderer>
+        <MudChip>@context.Name</MudChip>
+    </ItemRenderer>
+</MudDropContainer>
+
+@code {
+    private readonly List<DropItem> _items =
+    [
+        new() { Name = "Item 1", Selector = "1" },
+        new() { Name = "Item 2", Selector = "1" }
+    ];
+
+    public class DropItem
+    {
+        public required string Name { get; init; }
+
+        public required string Selector { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -46,6 +46,7 @@ namespace MudBlazor.UnitTests.Components
             zone.NoDropClass.Should().BeNullOrEmpty();
             zone.OnlyZone.Should().BeFalse();
             zone.AllowReorder.Should().BeFalse();
+            zone.Horizontal.Should().BeFalse();
         }
 
         [Test]
@@ -1288,5 +1289,17 @@ namespace MudBlazor.UnitTests.Components
             var containerComponent = comp.FindComponent<MudDropContainer<DropzoneBasicTest.SimpleDropItem>>();
             containerComponent.Instance.GetTransactionOriginZoneIdentifier().Should().Be("Column 1");
         }
+        [Test]
+        public void DropZone_Reorder_HorizontalPreviewStartClass()
+        {
+            var comp = Context.Render<DropzoneHorizontalReorderTest>();
+
+            var horizontalDropZone = comp.Find(".mud-drop-zone");
+            var previewStart = horizontalDropZone.Children[1];
+
+            previewStart.ClassList.Should().Contain("mud-drop-item-preview-start");
+            previewStart.ClassList.Should().Contain("mud-drop-item-preview-start-horizontal");
+        }
+
     }
 }

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor
@@ -44,7 +44,7 @@
                         Item="default"
                         ZoneIdentifier="@Identifier"
                         Disabled="true" HideContent="false"
-                        Class="mud-drop-item-preview-start" />
+                        Class="@PreviewStartClassname" />
             }
         }
         @foreach (var item in items)

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -172,6 +172,16 @@ namespace MudBlazor
         public bool AllowReorder { get; set; }
 
         /// <summary>
+        /// Displays reorder preview positions horizontally.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DropZone.Behavior)]
+        public bool Horizontal { get; set; }
+
+        /// <summary>
         /// Allows this zone to only receive dropped items.
         /// </summary>
         /// <remarks>
@@ -267,6 +277,11 @@ namespace MudBlazor
         protected string PlaceholderClassname =>
             new CssBuilder("border-2 mud-border-primary border-dashed mud-chip-text mud-chip-color-primary pa-4 mud-dropitem-placeholder")
                 .AddClass("d-none", !AllowReorder || Container?.TransactionInProgress() == false || Container?.GetTransactionCurrentZoneIdentifier() != Identifier)
+                .Build();
+
+        protected string PreviewStartClassname =>
+            new CssBuilder("mud-drop-item-preview-start")
+                .AddClass("mud-drop-item-preview-start-horizontal", Horizontal)
                 .Build();
 
         #endregion

--- a/src/MudBlazor/Styles/components/_dropzone.scss
+++ b/src/MudBlazor/Styles/components/_dropzone.scss
@@ -33,6 +33,11 @@
   left: 0;
   z-index: +1;
   user-select: none;
+
+  &.mud-drop-item-preview-start-horizontal {
+    height: 100%;
+    width: 20px;
+  }
 }
 
 .mud-drop-item {


### PR DESCRIPTION
### Motivation
- Provide visual support for horizontal reordering in `MudDropZone` so reorder previews render correctly in horizontal layouts.
- Expose a simple API to opt-in to horizontal previews via a component parameter.
- Update documentation and examples to demonstrate horizontal reorder usage.

### Description
- Added a new `bool` parameter `Horizontal` to `MudDropZone` to indicate horizontal reorder preview orientation and defaulted it to `false`.
- Introduced `PreviewStartClassname` in `MudDropZone` and replaced the hard-coded preview start class usage with `Class="@PreviewStartClassname"` in the component markup.
- Added CSS variant `.mud-drop-item-preview-start-horizontal` in `_dropzone.scss` to swap preview dimensions for horizontal layouts.
- Updated docs page and example `DropZoneItemSelectorReorderingExample.razor` to mention `Horizontal` and to demonstrate a horizontal drop zone by setting `Horizontal="@(i == 1)"` and the appropriate container classes.
- Added a small test viewer component `DropzoneHorizontalReorderTest.razor` used by tests and extended `DropZoneTests` to assert the horizontal preview start class and the `Horizontal` default in `DropZone_Defaults`.

### Testing
- Ran unit tests in `MudBlazor.UnitTests.Components.DropZoneTests`, including `DropZone_Defaults` and the new `DropZone_Reorder_HorizontalPreviewStartClass`, and they passed.
- Rendered the updated example `DropZoneItemSelectorReorderingExample` in the docs viewer to verify the horizontal example renders without errors (automated viewer test exercised via unit test harness and succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad733b3600832db7213144ee652f60)